### PR TITLE
Dependency check cache and suppress_writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Dependencies check timestamp
+.fsp_deps_timestamp
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/singleton.py
+++ b/src/singleton.py
@@ -28,6 +28,7 @@ def init():
     global VERBOSITY_LEVEL #-1 quite. 1,2,3 for v, vv, vvv respectively
     global DRY_RUN #Run a FSP Action, only checking permissions
     global NODEPS #Skip Dependency Checks
+    global SUPPRESS_WRITES #Script will not produce log files
 
     global RETRY_BLOCK_COUNT, RETRY_RANGE_COUNT, RETRY_JOB_COUNT
     RETRY_BLOCK_COUNT = 10


### PR DESCRIPTION
This is a rebase of 2 commits:

Completed Dependency Check Cache

A hidden file is created when the dependency check passes then on next
re-entries to the script, the creation time stamp will be checked to see if
it is older than 7 days and if so run the dependency checker

Created suppress_writes cli arg option

Intended Use Case: Small devices such as an AWS snowcone that do not
have the space to store log files. Log files will be implemented in the
future
Refactored some arg parsing logic to make more readable. And added the
suppress_writes as a project scoped variable in singleton.py

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
