### PR TITLE
Fix EBS snapshot creation for non-512KiB aligned file sizes

### DIFF
--- a/src/fsp.py
+++ b/src/fsp.py
@@ -631,7 +631,7 @@ def upload(file_path, parent_snapshot_id):
         f.seek(0, os.SEEK_END)
         size = f.tell()
         gbsize = math.ceil(size / GIGABYTE)
-        chunks = size // CHUNK_SIZE
+        chunks = math.ceil(size / CHUNK_SIZE)
         split = np.array_split(range(chunks), singleton.NUM_JOBS)
         count = Counter(Manager(), 0)
         print("Size of", file_path, "is", size, "bytes and", chunks, "chunks")


### PR DESCRIPTION
# Pull Request (PR)

*Issue #, if available:*
N/A

*Description of changes:*
When creating EBS snapshots, data must be uploaded in 512KiB chunks [1]. Previously, if the input file or block device size was not aligned to 512KiB, the last chunk would be omitted.

This commit fixes that behavior to handle any file size correctly.

[1] https://docs.aws.amazon.com/ebs/latest/APIReference/API_PutSnapshotBlock.html

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*